### PR TITLE
Allow to pass a custom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ plugins: [
 ## Configuration
 - `blacklist`: Accepts HTML file names - HTML pages specified here would not be generated via HTMLWebpackPlugin
 - `chunkAssign`: Accepts HTML file names and chunk array - Assign chunks to be included into specific HTML pages
-
-## TO-DO's
-- Add a configuration option for custom source folder pathnames (currently defaults to `src` folder)
+- `path`: A path to search for `.html` files - Defaults to `webpack.context`
 
 ## Version
 v1.0.x

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 
 class HtmlWebpackImportStaticPages {
 	constructor(options) {
-		const { blacklist = [], chunkAssign = {} } = options;
+		const { blacklist = [], chunkAssign = {} } = options || {};
 		this.options = {
 			blacklist,
 			chunkAssign

--- a/index.js
+++ b/index.js
@@ -4,16 +4,19 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 
 class HtmlWebpackImportStaticPages {
 	constructor(options) {
-		const { blacklist = [], chunkAssign = {} } = options || {};
+		const { blacklist = [], chunkAssign = {}, path = null } = options || {};
 		this.options = {
 			blacklist,
-			chunkAssign
+			chunkAssign,
+			path
 		};
 	}
 
 	apply(compiler) {
+		const sourcePath = path.resolve(this.options.path || compiler.context);
+
 		// Obtain all files within the source folder, and generate an array
-		fs.readdirSync(path.resolve(__dirname, "../../src"))
+		fs.readdirSync(sourcePath)
 			// Filter through and compare with the blacklist
 			.filter(
 				(fileName) => fileName.endsWith(".html") && this.options.blacklist.indexOf(fileName.split(".html")[0]) == -1
@@ -35,7 +38,7 @@ class HtmlWebpackImportStaticPages {
 
 				// Call HtmlWebPackPlugin for every fileName map item
 				new HtmlWebPackPlugin({
-					template: `./src/${pluginArrItem}`,
+					template: path.join(sourcePath, pluginArrItem),
 					filename: pluginArrItem,
 					inject: "body",
 					chunksSortMode: "none",


### PR DESCRIPTION
Hi,

i found your plugin and found it interesting.

But when i was trying it, i faced a `TypeError` if the `options` parameter were not supplied.

Also, the plugin wasn't making use of `webpack.context` which indicates the project path.